### PR TITLE
chore: Fixed mission statement link

### DIFF
--- a/index.html
+++ b/index.html
@@ -200,7 +200,7 @@
                                     </li>
                                     <li>Community Maintained
                                         <ul>
-                                            <li>The project is maintained by a community of cloud-native contributors with an <a href="https://github.com/ublue-os/website/blob/main/docs/mission.md">explicit mission</a></li>
+                                            <li>The project is maintained by a community of cloud-native contributors with an <a href="mission.html">explicit mission</a></li>
                                         </ul>
                                     </li>
                                     <li>Unbridled customization


### PR DESCRIPTION
I'm aware more documentation needs to be linked and so forth.