### PR TITLE
chore: Link "bazzite-news" tag in News section

### DIFF
--- a/index.html
+++ b/index.html
@@ -606,7 +606,7 @@
                             </div>
                             
                             <div class="col-md-5 offset-md-1 text-start text-md-end pt-40 pt-sm-20">
-                                <a href="https://universal-blue.discourse.group/" target="_blank" class="link-flat underline align-middle" data-link-animate="y">Read more on Discourse <i class="mi-arrow-right size-18"></i></a>
+                                <a href="https://universal-blue.discourse.group/tag/bazzite-news" target="_blank" class="link-flat underline align-middle" data-link-animate="y">Read more on Discourse <i class="mi-arrow-right size-18"></i></a>
                             </div>
                             
                         </div>


### PR DESCRIPTION
Instead of linking the general forum for the "news" section, it might be better to link only threads tagged with the 'bazzite-news' since that may be the only interest are new announcements and changes.