### PR TITLE
fix: Announcement link as opposed to bazzite-news

### DIFF
--- a/index.html
+++ b/index.html
@@ -606,7 +606,7 @@
                             </div>
                             
                             <div class="col-md-5 offset-md-1 text-start text-md-end pt-40 pt-sm-20">
-                                <a href="https://universal-blue.discourse.group/tag/bazzite-news" target="_blank" class="link-flat underline align-middle" data-link-animate="y">Read more on Discourse <i class="mi-arrow-right size-18"></i></a>
+                                <a href="https://universal-blue.discourse.group/tag/announcements" target="_blank" class="link-flat underline align-middle" data-link-animate="y">Read more on Discourse <i class="mi-arrow-right size-18"></i></a>
                             </div>
                             
                         </div>


### PR DESCRIPTION
Forgot that was visable only to mods/admins on Discourse.