### PR TITLE
feat: Add documentation link for base images.

### DIFF
--- a/index.html
+++ b/index.html
@@ -496,6 +496,8 @@
                                                 </div>
                                                 <a href="https://github.com/orgs/ublue-os/packages" target="_blank" class="btn btn-mod btn-large btn-round btn-hover-anim"><span>View All Base Images</span></a>
                                             </div>
+                                            <span style="color:#555;margin-top:30px;">Read our <a href="https://universal-blue.discourse.group/docs?topic=868" targt="_blank">documentation</a> on base images.</span>
+
                                             
                                         </div>                                
                                     </div>


### PR DESCRIPTION
Users who want the base image can be redirected to the [documentation](https://universal-blue.discourse.group/docs?topic=868) relevant to that.

![base docs](https://github.com/ublue-os/universal-blue-org/assets/121328689/a2c3fb70-e3f0-4011-b513-e018acaf95ba)

I know we don't want to advertise them, but users will be asking regardless.  I decided we should point them to the right direction to avoid more questions piling up in our Discourse, Discord, Github issue trackers, and Mastodon comments.

Feel free to edit this documentation linked to give better clarification on why users should not daily drive these particular images over the end-user focused.

Edit: I just read [this](https://mastodon.sdf.org/@kylegospo/112158360772511984) comment.  Maybe we don't need this now.