### PR TITLE
Add a new section for end-user image documentation

### DIFF
--- a/documentation.html
+++ b/documentation.html
@@ -1,0 +1,267 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        
+        <title>Universal Blue &#8211; Contributing</title>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <meta name="theme-color" content="#4051b5" />
+        <meta name="msapplication-config" content="none">
+
+        <!-- Favicon -->
+        <link rel="icon" href="content/favicon-new.png" type="image/png" sizes="any">
+        <!--<link rel="icon" href="content/favicon.svg" type="image/svg+xml">-->       
+
+        <!-- Preconnect -->
+        <link rel="preconnect" href="https://fonts.googleapis.com">
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+        <link rel="preconnect" href="https://cdnjs.cloudflare.com">
+        <link rel="preconnect" href="https://repobeats.axiom.co">
+        <link rel="preconnect" href="https:///universal-blue.discourse.group">
+
+        <!-- CSS -->
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.1.3/css/bootstrap.min.css" integrity="sha512-GQGU0fMMi238uA+a/bdWJfpUGKUkBdgfFdgBm72SUQ6BeyWjoY/ton0tEjH+OSH9iP4Dfh+7HM0I9f5eR0L/4w==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+        <link rel="stylesheet" href="css/style5.css">
+        <link rel="stylesheet" href="css/style-responsive.css">
+        <link rel="stylesheet" href="css/vertical-rhythm.min.css">
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/OwlCarousel2/2.3.4/assets/owl.carousel.min.css" integrity="sha512-tS3S5qG0BlhnQROyJXvNjeEM4UpMXHrQfTGmbQ1gKmelCxlSEBUaxhRBj/EFTzpbP4RVSrpEikbmdJobCvhE3g==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+        <link rel="stylesheet" href="css/splitting.css">
+        <link rel="stylesheet" href="css/YTPlayer.css">
+        <link rel="stylesheet" href="css/main.css">
+
+        <!-- Google Fonts -->
+        <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;700&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@300&display=swap" rel="stylesheet">
+
+        <!-- Font Awesome -->
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/fontawesome.min.css" integrity="sha512-d0olNN35C6VLiulAobxYHZiXJmq+vl+BGIgAxQtD5+kqudro/xNMvv2yIHAciGHpExsIbKX3iLg+0B6d0k4+ZA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/solid.min.css" integrity="sha512-pZlKGs7nEqF4zoG0egeK167l6yovsuL8ap30d07kA5AJUq+WysFlQ02DLXAmN3n0+H3JVz5ni8SJZnrOaYXWBA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/brands.min.css" integrity="sha512-8RxmFOVaKQe/xtg6lbscU9DU0IRhURWEuiI0tXevv+lXbAHfkpamD4VKFQRto9WgfOJDwOZ74c/s9Yesv3VvIQ==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    
+    </head>
+    <body class="appear-animate simple-page">
+        
+        <!-- Page Loader -->        
+        <div class="page-loader">
+            <div class="loader">Loading...</div>
+        </div>
+        <!-- End Page Loader -->
+
+        <!-- Skip to Content -->
+        <a href="#main" class="btn skip-to-content">Skip to Content</a>
+        <!-- End Skip to Content -->
+        
+        <!-- Page Wrap -->
+        <div class="page" id="top">
+            
+            <!-- Navigation Panel -->
+            <nav class="main-nav transparent stick-fixed wow-menubar wch-unset">
+                <div class="main-nav-sub full-wrapper">
+                    
+                    <!-- Logo -->
+                    <div class="nav-logo-wrap local-scroll">
+                        <a href="https://universal-blue.org/" class="logo">
+                            <img src="content/ublue-header-white.svg" alt="Universal Blue" width="2732" height="692" />
+                        </a>
+                    </div>
+                    
+                    <!-- Mobile Menu Button -->
+                    <div class="mobile-nav" role="button" tabindex="0">
+                        <i class="mobile-nav-icon"></i>
+                        <span class="visually-hidden">Menu</span>
+                    </div>
+                    
+                    <!-- Main Menu -->
+                    <div class="inner-nav desktop-nav">
+                        <ul class="clearlist scroll-nav local-scroll">
+                            <li><a href="https://universal-blue.org">Return Home</a></li>
+                        </ul>                    
+                    </div>
+                    <!-- End Main Menu -->
+                    
+                </div>
+            </nav>
+            <!-- End Navigation Panel -->
+            
+            <main id="main">
+            
+                <!-- Content Section -->
+                <section class="page-section" id="content">
+                    <div class="container position-relative">
+                    
+                        <div class="row mb-60 mb-xs-30">
+                            
+                            <div class="col-12">
+                                <h3 class="section-title mb-0"><span class="wow charsAnimIn" data-splitting="chars">End-User Image Documentation</span></h3>
+                            </div> 
+                          
+                        </div>
+<div class="row wow fadeInUp" data-wow-delay="0.25s">
+  
+  <p>
+                              
+<ul>
+<li><p><a href="https://docs.getaurora.dev/"><strong>Aurora Documentation</strong></a></p>
+</li>
+<li><p><a href="https://docs.bazzite.gg"><strong>Bazzite Documentation</strong></a></p>
+<li><p><a href="https://docs.projectbluefin.io/"><strong>Bluefin Documentation</strong></a></p>
+</li>
+<li><p><a href="https://github.com/ublue-os/ucore/blob/main/README.md"><strong>uCore Documentation</strong></a></p>
+</li>
+</ul>
+
+                  <!-- End Content Section -->
+           </main>
+            
+            <!-- Footer -->
+            <footer class="page-section footer bg-gray-light-1 pb-30">
+                <div class="container">
+                    
+                    <div class="row pb-120 pb-sm-80 pb-xs-50">
+                                                
+                        <div style="text-align:center;" class="col-md-4 col-lg-3 text-gray mb-sm-50">
+                            
+                            <div class="mb-10 footer-logo">
+                                <img src="content/ublue-mini.svg" width="100" height="100" alt="Universal Blue" />
+                            </div>
+                            
+                            <p>
+                                Your community toolkit designed to reboot the Linux desktop. Built for the love of the game. Welcome to indie Cloud Native. 
+                            </p>
+                            
+                        </div>
+                        
+                        <div class="col-md-7 offset-md-1 offset-lg-2">                            
+                            <div class="row mt-n30">
+                                
+                                <!-- Footer Widget -->
+                                <!--<div class="col-sm-4 mt-80">
+                                    
+                                </div>-->
+                                <!-- End Footer Widget -->
+                                
+                                <!-- Footer Widget -->
+                                <div class="col-sm-6 mt-80">
+                                    
+                                    <h3 class="fw-title">Documentation</h3>
+                                    
+                                    <ul class="fw-menu clearlist">
+                                        <li>
+                                            <a href="mission.html">
+                                                Mission
+                                            </a>
+                                        </li>
+                                        <li>
+                                            <a href="values.html">
+                                                Values
+                                            </a>
+                                        </li>
+                                        <li>
+                                            <a href="membership.html">
+                                                Membership
+                                            </a>
+                                        </li>
+                                        <li>
+                                            <a href="code-of-conduct.html">
+                                                Code of Conduct
+                                            </a>
+                                        </li>
+                                        <li>
+                                            <a href="contributing.html">
+                                                Contributing
+                                            </a>
+                                        </li>
+                                    </ul>
+                                    
+
+                                </div>
+                                <!-- End Footer Widget -->   
+
+                                <!-- Footer Widget -->
+                                <div class="col-sm-6 mt-80">
+                                    
+                                    <h3 class="fw-title">Social Media</h3>
+                                    
+                                    <ul class="fw-menu clearlist">
+                                        <li>
+                                            <a href="https://universal-blue.discourse.group/" rel="noopener nofollow" target="_blank">
+                                                <i class="fa-brands fa-discourse"></i>
+                                                Discourse
+                                            </a>
+                                        </li>
+                                        <li>
+                                            <a href="https://fosstodon.org/@UniversalBlue" rel="noopener nofollow" target="_blank">
+                                                <i class="fa-brands fa-mastodon"></i>
+                                                Mastodon
+                                            </a>
+                                        </li>
+                                        <li>
+                                            <a href="https://www.youtube.com/c/JorgeCastro/videos" rel="noopener nofollow" target="_blank">
+                                                <i class="fa-brands fa-youtube"></i>
+                                                Youtube
+                                            </a>
+                                        </li>
+                                        <li>
+                                            <a href="https://discord.gg/WEu6BdFEtp" rel="noopener nofollow" target="_blank">
+                                                <i class="fa-brands fa-discord"></i>
+                                                Discord
+                                            </a>
+                                        </li>
+                                        <li>
+                                            <a href="https://www.answeroverflow.com/c/1072614816579063828" rel="noopener nofollow" target="_blank">
+                                                <i class="fa-solid fa-comment"></i>
+                                                Answer Overflow
+                                            </a>
+                                        </li>
+                                    </ul>
+                                    
+                                </div>
+                                <!-- End Footer Widget -->                             
+                                
+                            </div>                            
+                        </div>
+                        
+                    </div>
+                    
+                    <!-- Footer Text -->
+                    <div class="row text-gray">
+                        
+                        <div class="col-md-4 col-lg-3">
+                            <b>© Universal Blue <span id="current-year">2024</span></b>
+                        </div>
+                        
+                        <div class="col-md-7 offset-md-1 offset-lg-2 clearfix">
+                            
+                            <span style="font-size:12px;">Universal Blue is not affiliated with Red Hat or the Fedora Project.</span>
+                            
+                            <!-- Back to Top Link -->
+                            <div class="local-scroll float-end mt-n20 mt-sm-10">
+                                <a href="#top" class="link-to-top">                                
+                                    <i class="mi-arrow-up size-24"></i>
+                                    <span class="visually-hidden">Scroll to top</span>
+                                </a>
+                            </div>
+                            <!-- End Back to Top Link -->
+                            
+                        </div>
+                        
+                    </div>
+                    <!-- End Footer Text --> 
+                    
+                 </div>                 
+            </footer>
+            <!-- End Footer -->
+        
+        </div>
+        <!-- End Page Wrap -->      
+        
+        <!-- JS -->
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js" integrity="sha512-894YE6QWD5I59HgZOGReFYm4dnWc1Qt5NtvYSaNcOP+u1T9qYdvdihz0PPSiiqn/+/3e7Jo4EaG7TubfWGUrMQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.1.3/js/bootstrap.bundle.min.js" integrity="sha512-pax4MlgXjHEPfCwcJLQhigY7+N8rt6bVvWLFyUMuxShv170X53TRzGPmPkZmGBhk+jikR8WBM4yl7A9WMHHqvg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/OwlCarousel2/2.3.4/owl.carousel.min.js" integrity="sha512-bPs7Ae6pVvhOSiIcyUClR7/q2OAsRiovw4vAkX+zJbw3ShAeeqezq50RIIcIURq7Oa20rW2n2q+fyXBNcU9lrw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+        <script src="js/plugins.js"></script>
+        <script src="js/all.js"></script>
+        <script type="text/javascript" src="https:///universal-blue.discourse.group/javascripts/embed-topics.js"></script>
+        <!-- End JS -->
+    </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -886,6 +886,11 @@
                                     
                                     <ul class="fw-menu clearlist">
                                         <li>
+                                            <a href="documentation.html">
+                                                Images
+                                            </a>
+                                        </li>
+                                        <li>
                                             <a href="mission.html">
                                                 Mission
                                             </a>


### PR DESCRIPTION
A new page that links documentation for Aurora, Bazzite, Bluefin, and uCore.  I also want this page to be linked on the Discourse forums on the documentation sidebar link replacing the forum post version. 