### PR TITLE
Fix: Links on ublue website

### DIFF
--- a/contributing.html
+++ b/contributing.html
@@ -135,16 +135,16 @@
                             </p>
                             <h2 id="i-have-a-question">I Have a Question</h2>
                             <blockquote>
-                               <p>If you want to ask a question, ask in the <a href="https://github.com/orgs/ublue-os/discussions">discussion forum</a></p>
+                               <p>If you want to ask a question, ask in the <a href="https://universal-blue.discourse.group/">discussion forum</a></p>
                             </blockquote>
                             <h2 id="i-want-to-contribute">I Want To Contribute</h2>
                             <blockquote>
                                <h3 id="legal-notice">Legal Notice</h3>
                                <p>When contributing to this project, you must agree that you have authored 100% of the content, that you have the necessary rights to the content and that the content you contribute may be provided under the project license.</p>
                             </blockquote>
-                            <p>Generally speaking we try to follow the <a href="http://lazyconcens.us/">Lazy Concensus</a> model of development to keep the builds healthy and ourselves happy. </p>
+                            <p>Generally speaking we try to follow the <a href="https://community.apache.org/committers/decisionMaking.html#lazy-consensus">Lazy Consensus</a> model of development to keep the builds healthy and ourselves happy. </p>
                             <ul>
-                               <li>If you&#39;re looking for concensus to make a decision post an issue for feedback and remember to account for timezones and weekends/holidays/work time. </li>
+                               <li>If you&#39;re looking for consensus to make a decision post an issue for feedback and remember to account for timezones and weekends/holidays/work time. </li>
                                <li>We want people to be opinionated in their builds so we&#39;re more of a loose confederation of repos than a top-down org.</li>
                                <li>Try not to merge your own stuff, ask for a review. At some point when we have enough reviewers we&#39;ll be turning on branch protection. </li>
                             </ul>

--- a/index.html
+++ b/index.html
@@ -131,7 +131,7 @@
                                 <div class="col-12 d-flex align-items-center mb-sm-60">
                                     <div style="margin:auto;">
                                         <div class="local-scroll mt-n10 wow fadeInUp wch-unset" data-wow-delay="0.7s" data-wow-duration="1.2s" data-wow-offset="0">
-                                            <a href="#about" class="btn btn-mod btn-large btn-round btn-hover-anim align-middle me-2 me-sm-5 mt-10"><span>About Us</span></a>
+                                            <a href="#who" class="btn btn-mod btn-large btn-round btn-hover-anim align-middle me-2 me-sm-5 mt-10"><span>About Us</span></a>
                                             <a href="#cloud-native" class="link-flat align-middle mt-10" data-link-animate="y"><i class="icon-play size-13 me-1"></i> What is cloud native?</a>
                                         </div>
                                         


### PR DESCRIPTION
I encountered a broken link.
Then, I checked the [link checker](https://github.com/w3c/link-checker/) from w3c for more broken links.

The Link Checker gave a notice about this being https://universal-blue.discourse.group/javascripts/embed-topics.js, but I was able to pull that file. It's probably a false positive, but I don't know enough about discourse to verify.

----

Also, link checker complains about "duplicate empty and matching anchors" for =community-and-project= ids for [this page](https://universal-blue.org/mission.html) on h1 (line 102) and h1 (line 115)